### PR TITLE
feat: add first class fare calculation with East Rail Line rules

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -17,6 +17,7 @@
   "directRouteLabel": "Direct Route",
   "viaLabel": "Via",
   "cheapestOptionLabel": "Cheapest Option",
+  "firstClassFareLabel": "First Class Fare",
   "paymentMethods": {
     "OCT_ADT_FARE": "Adult Octopus",
     "OCT_STD_FARE": "Student Octopus",

--- a/public/locales/zh-Hant/translation.json
+++ b/public/locales/zh-Hant/translation.json
@@ -17,6 +17,7 @@
   "directRouteLabel": "直接路線",
   "viaLabel": "經",
   "cheapestOptionLabel": "最平選項",
+  "firstClassFareLabel": "頭等車費",
   "paymentMethods": {
     "OCT_ADT_FARE": "成人八達通",
     "OCT_STD_FARE": "學生八達通",

--- a/src/data/fareService.ts
+++ b/src/data/fareService.ts
@@ -147,3 +147,177 @@ export function getFare(
 export function getAllFareRecords(): FareRecord[] {
     return fareData;
 }
+
+// First class fare calculation types and functions
+export type StationRegion = 'HK_ISLAND' | 'KOWLOON' | 'NEW_TERRITORIES';
+
+export function getStationRegion(stationName: string): StationRegion {
+  if (isHongKongIslandStation(stationName)) {
+    return 'HK_ISLAND';
+  } else if (isKowloonStation(stationName)) {
+    return 'KOWLOON';
+  } else {
+    return 'NEW_TERRITORIES';
+  }
+}
+
+export function calculateFirstClassSurcharge(
+  startStation: string,
+  destStation: string,
+  paymentMethod: PaymentMethod
+): number {
+  const startRegion = getStationRegion(startStation);
+  const destRegion = getStationRegion(destStation);
+  
+  // Get station IDs
+  const startId = getStationId(startStation);
+  const destId = getStationId(destStation);
+  const taiWaiId = getStationId('Tai Wai');
+  const hungHomId = getStationId('Hung Hom');
+  const admiraltyId = getStationId('Admiralty');
+  
+  if (!startId || !destId || !taiWaiId || !hungHomId || !admiraltyId) {
+    return 0;
+  }
+
+  // Rule 1: One end on EAL NT station, other end on non-EAL Kowloon/NT station
+  if ((startRegion === 'NEW_TERRITORIES' && destRegion !== 'HK_ISLAND') ||
+      (destRegion === 'NEW_TERRITORIES' && startRegion !== 'HK_ISLAND')) {
+    // Get fare from NT station to Tai Wai
+    const ntStation = startRegion === 'NEW_TERRITORIES' ? startId : destId;
+    const surcharge = getFare(ntStation, taiWaiId, 'OCT_ADT_FARE') || 0;
+    return surcharge;
+  }
+
+  // Rule 2: Both ends in Kowloon/NT, no EAL/TML stations involved
+  if (startRegion !== 'HK_ISLAND' && destRegion !== 'HK_ISLAND') {
+    return 4.0; // Minimum standard adult Octopus fare
+  }
+
+  // Rule 3: One end on HK Island
+  if (startRegion === 'HK_ISLAND' || destRegion === 'HK_ISLAND') {
+    // Sub-rule 3a: Other end in Kowloon
+    if (startRegion === 'KOWLOON' || destRegion === 'KOWLOON') {
+      const surcharge = getFare(admiraltyId, hungHomId, 'OCT_ADT_FARE') || 0;
+      return surcharge;
+    }
+    // Sub-rule 3b: Other end in TML Hin Keng to Wu Kai Sha
+    const surcharge = getFare(admiraltyId, taiWaiId, 'OCT_ADT_FARE') || 0;
+    return surcharge;
+  }
+
+  return 0;
+}
+
+// Helper function to check if a journey is entirely on East Rail Line
+function isEastRailLineJourney(startStation: string, destStation: string): boolean {
+  const eastRailStations = [
+    "Admiralty",
+    "Exhibition Centre",
+    "Hung Hom",
+    "Mong Kok East",
+    "Kowloon Tong",
+    "Tai Wai",
+    "Sha Tin",
+    "Fo Tan",
+    "Racecourse",
+    "University",
+    "Tai Po Market",
+    "Tai Wo",
+    "Fanling",
+    "Sheung Shui",
+    "Lo Wu",
+    "Lok Ma Chau"
+  ];
+  return eastRailStations.includes(startStation) && eastRailStations.includes(destStation);
+}
+
+export function calculateFirstClassFare(
+  startStation: string,
+  destStation: string,
+  paymentMethod: PaymentMethod
+): number {
+  const baseFare = getFare(getStationId(startStation) || '', getStationId(destStation) || '', paymentMethod) || 0;
+  const childFare = getFare(getStationId(startStation) || '', getStationId(destStation) || '', 'OCT_CON_CHILD_FARE') || 0;
+  
+  // Check if journey is entirely on East Rail Line
+  if (isEastRailLineJourney(startStation, destStation)) {
+    // For East Rail Line journeys, first class fare is twice the standard fare
+    if (paymentMethod === 'OCT_STD_FARE') {
+      // Student: Base fare + Adult standard fare surcharge
+      return baseFare + baseFare;
+    } else if (paymentMethod === 'OCT_JOYYOU_SIXTY_FARE') {
+      // JoyYou 60+: $2 + Adult standard fare surcharge
+      return 2 + baseFare;
+    } else if (paymentMethod === 'OCT_CON_ELDERLY_FARE' || paymentMethod === 'OCT_CON_PWD_FARE') {
+      // Elderly/PWD: $2 + Child standard fare surcharge
+      return 2 + childFare;
+    } else if (paymentMethod === 'OCT_CON_CHILD_FARE' || paymentMethod === 'SINGLE_CON_CHILD_FARE') {
+      // Child: Base fare + Child standard fare surcharge
+      return baseFare + childFare;
+    } else {
+      // Regular fare: Base fare + Base fare (double the standard fare)
+      return baseFare + baseFare;
+    }
+  }
+
+  // For non-East Rail Line journeys, use the original surcharge calculation
+  const surcharge = calculateFirstClassSurcharge(startStation, destStation, paymentMethod);
+  
+  // Apply special rules for different passenger categories
+  if (paymentMethod === 'OCT_STD_FARE') {
+    // Student: Base fare + Adult standard fare surcharge
+    return baseFare + surcharge;
+  } else if (paymentMethod === 'OCT_JOYYOU_SIXTY_FARE') {
+    // JoyYou 60+: $2 + Adult standard fare surcharge
+    return 2 + surcharge;
+  } else if (paymentMethod === 'OCT_CON_ELDERLY_FARE' || paymentMethod === 'OCT_CON_PWD_FARE') {
+    // Elderly/PWD: $2 + Child standard fare surcharge
+    return 2 + childFare;
+  } else if (paymentMethod === 'OCT_CON_CHILD_FARE' || paymentMethod === 'SINGLE_CON_CHILD_FARE') {
+    // Child: Base fare + Child standard fare surcharge
+    return baseFare + childFare;
+  } else {
+    // Regular fare + surcharge
+    return baseFare + surcharge;
+  }
+}
+
+// Station region helper functions
+export function isHongKongIslandStation(stationName: string): boolean {
+  const hkIslandStations: string[] = [
+    // Island Line
+    "Kennedy Town", "HKU", "Sai Ying Pun", "Sheung Wan", "Central",
+    "Admiralty", "Wan Chai", "Causeway Bay", "Tin Hau", "Fortress Hill",
+    "North Point", "Quarry Bay", "Tai Koo", "Sai Wan Ho", "Shau Kei Wan",
+    "Heng Fa Chuen", "Chai Wan",
+    // South Island Line
+    "Ocean Park", "Wong Chuk Hang", "Lei Tung", "South Horizons",
+    // Tung Chung Line / Airport Express
+    "Hong Kong",
+    // East Rail Line
+    "Exhibition Centre"
+  ];
+  return hkIslandStations.includes(stationName);
+}
+
+export function isKowloonStation(stationName: string): boolean {
+  const kowloonStations: string[] = [
+    // Kwun Tong Line
+    "Whampoa", "Ho Man Tin", "Yau Ma Tei", "Mong Kok", "Prince Edward",
+    "Shek Kip Mei", "Kowloon Tong", "Lok Fu", "Wong Tai Sin",
+    "Diamond Hill", "Choi Hung", "Kowloon Bay", "Ngau Tau Kok",
+    "Kwun Tong", "Lam Tin", "Yau Tong",
+    // Tsuen Wan Line
+    "Tsim Sha Tsui", "Jordan", "Sham Shui Po", "Cheung Sha Wan",
+    "Lai Chi Kok", "Mei Foo",
+    // Tuen Ma Line
+    "Kai Tak", "Sung Wong Toi", "To Kwa Wan", "Hung Hom",
+    "East Tsim Sha Tsui", "Austin", "Nam Cheong",
+    // East Rail Line
+    "Mong Kok East",
+    // Tung Chung Line / Airport Express
+    "Kowloon", "Olympic"
+  ];
+  return kowloonStations.includes(stationName);
+}


### PR DESCRIPTION
- Add first class fare calculation for East Rail Line journeys - Implement special fare rules for different passenger categories - Use actual child fare data instead of estimated half fare - Add translations for first class fare display - Update UI to show first class fares in results