### PR TITLE
Fix reverse button overlapping station inputs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -383,7 +383,8 @@ function App() {
                       }}
                       sx={{
                         position: { xs: 'static', md: 'absolute' },
-                        left: { md: -28 },
+                        left: { md: '-50%' },
+                        transform: { xs: 'rotate(90deg)', md: 'translateX(-50%)' },
                         backgroundColor: 'white',
                         border: '2px solid #667eea',
                         color: '#667eea',
@@ -392,7 +393,6 @@ function App() {
                           color: 'white',
                         },
                         mb: { xs: 2, md: 0 },
-                        transform: { xs: 'rotate(90deg)', md: 'none' },
                       }}
                     >
                       <SwapHorizIcon />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -383,7 +383,7 @@ function App() {
                       }}
                       sx={{
                         position: { xs: 'static', md: 'absolute' },
-                        left: { md: '-50%' },
+                        left: { md: 0 },
                         transform: { xs: 'rotate(90deg)', md: 'translateX(-50%)' },
                         backgroundColor: 'white',
                         border: '2px solid #667eea',
@@ -393,6 +393,7 @@ function App() {
                           color: 'white',
                         },
                         mb: { xs: 2, md: 0 },
+                        zIndex: 1,
                       }}
                     >
                       <SwapHorizIcon />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -355,66 +355,58 @@ function App() {
                 )}
 
                 <Grid container spacing={3}>
-                  {/* Station Selectors */}
-                  <Grid size={{ xs: 12, md: 6 }}>
-                    <StationSelector
-                      value={startStation}
-                      onChange={setStartStation}
-                      label={t('startStationLabel')}
-                      excludeStation={destStation}
-                    />
-                  </Grid>
-
-                  <Grid
-                    size={{ xs: 12, md: 6 }}
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      position: 'relative',
-                    }}
-                  >
-                    {/* Swap button for mobile/desktop */}
-                    <IconButton
-                      onClick={() => {
-                        const temp = startStation;
-                        setStartStation(destStation);
-                        setDestStation(temp);
-                      }}
+                  {/* Station Selectors - Desktop Flex Layout */}
+                  <Grid size={{ xs: 12 }}>
+                    <Box
                       sx={{
-                        position: { xs: 'static', md: 'absolute' },
-                        left: { md: 0 },
-                        transform: { xs: 'rotate(90deg)', md: 'translateX(-50%)' },
-                        backgroundColor: 'white',
-                        border: '2px solid #667eea',
-                        color: '#667eea',
-                        '&:hover': {
-                          backgroundColor: '#667eea',
-                          color: 'white',
-                        },
-                        mb: { xs: 2, md: 0 },
-                        zIndex: 1,
+                        display: { xs: 'flex', md: 'flex' },
+                        flexDirection: { xs: 'column', md: 'row' },
+                        alignItems: 'center',
+                        gap: { xs: 2, md: 2 },
                       }}
                     >
-                      <SwapHorizIcon />
-                    </IconButton>
-                    <Box sx={{ width: '100%', display: { xs: 'none', md: 'block' } }}>
-                      <StationSelector
-                        value={destStation}
-                        onChange={setDestStation}
-                        label={t('destStationLabel')}
-                        excludeStation={startStation}
-                      />
-                    </Box>
-                  </Grid>
+                      {/* Start Station */}
+                      <Box sx={{ flex: { xs: '1 1 auto', md: '1 1 0' }, width: { xs: '100%', md: 'auto' } }}>
+                        <StationSelector
+                          value={startStation}
+                          onChange={setStartStation}
+                          label={t('startStationLabel')}
+                          excludeStation={destStation}
+                        />
+                      </Box>
 
-                  <Grid size={{ xs: 12, md: 6 }} sx={{ display: { xs: 'block', md: 'none' } }}>
-                    <StationSelector
-                      value={destStation}
-                      onChange={setDestStation}
-                      label={t('destStationLabel')}
-                      excludeStation={startStation}
-                    />
+                      {/* Swap Button */}
+                      <IconButton
+                        onClick={() => {
+                          const temp = startStation;
+                          setStartStation(destStation);
+                          setDestStation(temp);
+                        }}
+                        sx={{
+                          backgroundColor: 'white',
+                          border: '2px solid #667eea',
+                          color: '#667eea',
+                          '&:hover': {
+                            backgroundColor: '#667eea',
+                            color: 'white',
+                          },
+                          transform: { xs: 'rotate(90deg)', md: 'none' },
+                          flexShrink: 0,
+                        }}
+                      >
+                        <SwapHorizIcon />
+                      </IconButton>
+
+                      {/* Destination Station */}
+                      <Box sx={{ flex: { xs: '1 1 auto', md: '1 1 0' }, width: { xs: '100%', md: 'auto' } }}>
+                        <StationSelector
+                          value={destStation}
+                          onChange={setDestStation}
+                          label={t('destStationLabel')}
+                          excludeStation={startStation}
+                        />
+                      </Box>
+                    </Box>
                   </Grid>
 
                   {/* Payment Method */}

--- a/src/data/mtrLines.ts
+++ b/src/data/mtrLines.ts
@@ -64,7 +64,7 @@ const LINE_METADATA: Record<string, Omit<MTRLine, 'stations'>> = {
     nameEn: 'East Rail Line',
     nameZh: '東鐵綫',
     color: '#5EB7E8',
-    textColor: '#000000',
+    textColor: '#FFFFFF',
   },
   TCL: {
     id: 'TCL',


### PR DESCRIPTION
- Fix reverse button overlap on desktop by using percentage-based positioning and centering transform instead of fixed pixel offset
- Change East Rail Line text color from black to white for better contrast on light blue background